### PR TITLE
feat(email_alias): read environment variables from file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,11 @@ if [[ ! -d /usr/local/bin ]]; then
   mkdir -p /usr/local/bin
 fi
 
+if [[ ! -d "$HOME/.scripts" ]]; then
+  echo "Creating ~/.scripts/ directory"
+  mkdir -p "$HOME/.scripts"
+fi
+
 for file in src/*.sh; do
   filename=$(basename "$file" .sh)
   cp "$file" "/usr/local/bin/$filename"

--- a/src/email_alias.sh
+++ b/src/email_alias.sh
@@ -7,8 +7,6 @@
 # Arguments:
 # $1 The prefix that should be applied to the randomly-generated string of characters. This is provided by the user.
 #
-# Environment variables:
-# SIMPLE_LOGIN_SUFFIX Shall be the domain name the email alias should be created with.
 # Variables stored in ~/.scripts/email_alias:
 # SIMPLE_LOGIN_SUFFIX Shall be the domain name the email alias should be created with. This shall be prefixed with the
 # `@` symbol, i.e. `@luke.example`.

--- a/src/email_alias.sh
+++ b/src/email_alias.sh
@@ -12,6 +12,7 @@
 # SIMPLE_LOGIN_API_TOKEN Shall be the API token used to communicate with SimpleLogin.
 #
 # Expected utilities:
+# curl: Used to make requests to SimpleLogin.
 # jq: Used to parse JSON responses from SimpleLogin.
 #
 set -e

--- a/src/email_alias.sh
+++ b/src/email_alias.sh
@@ -10,6 +10,8 @@
 # Environment variables:
 # SIMPLE_LOGIN_SUFFIX Shall be the domain name the email alias should be created with.
 # Variables stored in ~/.scripts/email_alias:
+# SIMPLE_LOGIN_SUFFIX Shall be the domain name the email alias should be created with. This shall be prefixed with the
+# `@` symbol, i.e. `@luke.example`.
 # SIMPLE_LOGIN_API_TOKEN Shall be the API token used to communicate with SimpleLogin.
 #
 # Expected utilities:

--- a/src/email_alias.sh
+++ b/src/email_alias.sh
@@ -9,6 +9,7 @@
 #
 # Environment variables:
 # SIMPLE_LOGIN_SUFFIX Shall be the domain name the email alias should be created with.
+# Variables stored in ~/.scripts/email_alias:
 # SIMPLE_LOGIN_API_TOKEN Shall be the API token used to communicate with SimpleLogin.
 #
 # Expected utilities:
@@ -16,6 +17,16 @@
 # jq: Used to parse JSON responses from SimpleLogin.
 #
 set -e
+
+# Read from config file
+config_file="$HOME/.scripts/email_alias"
+
+if [[ ! -f "$config_file" ]]; then
+  echo "Error: configuration file $config_file not found." >&2
+  exit 1
+fi
+
+source "$config_file"
 
 api_fqdn="https://app.simplelogin.io/api"
 auth_header="Authentication: $SIMPLE_LOGIN_API_TOKEN"

--- a/src/email_alias.sh
+++ b/src/email_alias.sh
@@ -16,7 +16,6 @@
 # curl: Used to make requests to SimpleLogin.
 # jq: Used to parse JSON responses from SimpleLogin.
 #
-set -e
 
 # Read from config file
 config_file="$HOME/.scripts/email_alias"


### PR DESCRIPTION
Storing the environment variables needed for `email_alias.sh` in `~/.scripts` is a more secure approach to placing them in `~/.zshrc`.